### PR TITLE
[Docs] useUpdateItemQuantity, order, Link

### DIFF
--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import {Styled, jsx} from 'theme-ui';
-import PropTypes from 'prop-types';
 import {useStaticQuery, graphql} from 'gatsby';
+import {Link} from '../components';
 
 const Layout = ({children}) => {
   const {
@@ -36,16 +36,14 @@ const Layout = ({children}) => {
               ❤️
             </span>{' '}
             by{' '}
-            <a href={`http://twitter.com/${twitterHandle}`}>{twitterHandle}.</a>
+            <Link url={`http://twitter.com/${twitterHandle}`}>
+              {twitterHandle}.
+            </Link>
           </Styled.p>
         </footer>
       </div>
     </Styled.root>
   );
-};
-
-Layout.propTypes = {
-  children: PropTypes.node.isRequired,
 };
 
 export {Layout};

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import {jsx, Link as ThemeUiLink} from 'theme-ui';
+import {Link as GatsbyLink} from 'gatsby';
+
+const EXTERNAL_URL_PATTERN = /^http/;
+
+export function Link({url, children, ...rest}) {
+  const isExternalUrl = EXTERNAL_URL_PATTERN.test(url);
+
+  if (isExternalUrl) {
+    return (
+      <ThemeUiLink href={url} {...rest}>
+        {children}
+      </ThemeUiLink>
+    );
+  } else {
+    return (
+      <ThemeUiLink as={GatsbyLink} to={url} {...rest}>
+        {children}
+      </ThemeUiLink>
+    );
+  }
+}

--- a/docs/src/components/examples/ExampleUseUpdateItemQuantity.js
+++ b/docs/src/components/examples/ExampleUseUpdateItemQuantity.js
@@ -1,0 +1,55 @@
+import React, {useState} from 'react';
+import {Flex, Button, Input} from 'theme-ui';
+import {
+  useUpdateItemQuantity,
+  useCartItems,
+} from 'gatsby-theme-shopify-manager';
+
+export function ExampleUseUpdateItemQuantity() {
+  const [quantity, setQuantity] = useState(1);
+  const [item] = useCartItems();
+  const updateItemQuantity = useUpdateItemQuantity();
+
+  async function updateQuantity() {
+    if (item == null) {
+      return;
+    }
+
+    const variantId = item.variant.id;
+
+    try {
+      await updateItemQuantity(variantId, quantity);
+      alert('Successfully updated the item quantity!');
+    } catch {
+      alert("There was a problem updating that item's quantity.");
+    }
+  }
+
+  const itemMarkup =
+    item == null ? (
+      <p>Your cart is empty.</p>
+    ) : (
+      <p>
+        {item.title} - {item.variant.title} ({item.quantity})
+      </p>
+    );
+
+  const formMarkup = (
+    <Flex sx={{alignItems: 'flex-start'}} as="form" onSubmit={updateQuantity}>
+      <Input
+        sx={{width: '50px', mr: 3}}
+        type="number"
+        defaultValue={quantity}
+        onChange={(event) => setQuantity(Number(event.target.value))}
+      />
+      <Button sx={{mb: 3}}>Update quantity</Button>
+    </Flex>
+  );
+
+  return (
+    <>
+      {itemMarkup}
+      {formMarkup}
+    </>
+  );
+}

--- a/docs/src/components/examples/index.js
+++ b/docs/src/components/examples/index.js
@@ -6,3 +6,4 @@ export {ExampleUseAddItemsToCart} from './ExampleUseAddItemsToCart';
 export {ExampleUseAddItemToCart} from './ExampleUseAddItemToCart';
 export {ExampleUseRemoveItemsFromCart} from './ExampleUseRemoveItemsFromCart';
 export {ExampleUseRemoveItemFromCart} from './ExampleUseRemoveItemFromCart';
+export {ExampleUseUpdateItemQuantity} from './ExampleUseUpdateItemQuantity';

--- a/docs/src/components/index.js
+++ b/docs/src/components/index.js
@@ -2,4 +2,5 @@ export {Product} from './Product';
 export {Layout} from './Layout';
 export {ExampleWithCode} from './ExampleWithCode';
 export {ControlStrip} from './ControlStrip';
+export {Link} from './Link';
 export * from './examples';

--- a/docs/src/content/Hooks.js
+++ b/docs/src/content/Hooks.js
@@ -1,7 +1,10 @@
+/** @jsx jsx */
+// eslint-disable-next-line
 import React from 'react';
+import {jsx, Box} from 'theme-ui';
 import {useStaticQuery, graphql} from 'gatsby';
 import {MDXRenderer} from 'gatsby-plugin-mdx';
-import {Link} from 'gatsby';
+import {Link} from '../components';
 
 export function Hooks() {
   const {
@@ -14,6 +17,9 @@ export function Hooks() {
             node {
               name
               childMdx {
+                frontmatter {
+                  order
+                }
                 body
                 tableOfContents
               }
@@ -24,7 +30,26 @@ export function Hooks() {
     `,
   );
 
-  const hooksDocumentationFiles = edges.map((edge) => edge.node);
+  const hooksDocumentationFiles = edges
+    .map((edge) => edge.node)
+    .sort((firstNode, secondNode) => {
+      const firstNodeFrontmatter = firstNode.childMdx.frontmatter;
+      const secondNodeFrontmatter = secondNode.childMdx.frontmatter;
+
+      if (firstNodeFrontmatter.order > secondNodeFrontmatter.order) {
+        return 1;
+      }
+
+      if (firstNodeFrontmatter.order < secondNodeFrontmatter.order) {
+        return -1;
+      }
+
+      if (firstNodeFrontmatter.title > secondNodeFrontmatter.title) {
+        return 1;
+      }
+
+      return -1;
+    });
 
   return (
     <>
@@ -34,13 +59,17 @@ export function Hooks() {
 
           return (
             <li key={hook.name}>
-              <Link to={`#${hookLink}`}>{hook.name}</Link>
+              <Link url={`#${hookLink}`}>{hook.name}</Link>
             </li>
           );
         })}
       </ul>
       {hooksDocumentationFiles.map((hook) => {
-        return <MDXRenderer key={hook.name}>{hook.childMdx.body}</MDXRenderer>;
+        return (
+          <Box key={hook.name} sx={{my: 5}}>
+            <MDXRenderer>{hook.childMdx.body}</MDXRenderer>
+          </Box>
+        );
       })}
     </>
   );

--- a/docs/src/content/hooks/useAddItemToCart.mdx
+++ b/docs/src/content/hooks/useAddItemToCart.mdx
@@ -1,3 +1,7 @@
+---
+order: 6
+---
+
 import {ExampleUseAddItemToCart, ExampleWithCode} from '../../components';
 
 ### useAddItemToCart()

--- a/docs/src/content/hooks/useAddItemsToCart.mdx
+++ b/docs/src/content/hooks/useAddItemsToCart.mdx
@@ -1,3 +1,7 @@
+---
+order: 5
+---
+
 import {ExampleUseAddItemsToCart, ExampleWithCode} from '../../components';
 
 ### useAddItemsToCart()

--- a/docs/src/content/hooks/useCart.mdx
+++ b/docs/src/content/hooks/useCart.mdx
@@ -1,3 +1,7 @@
+---
+order: 1
+---
+
 import {ExampleUseCart, ExampleWithCode} from '../../components';
 
 ### useCart()

--- a/docs/src/content/hooks/useCartCount.mdx
+++ b/docs/src/content/hooks/useCartCount.mdx
@@ -1,3 +1,7 @@
+---
+order: 3
+---
+
 import {ExampleUseCartCount, ExampleWithCode} from '../../components';
 
 ### useCartCount()

--- a/docs/src/content/hooks/useCartItems.mdx
+++ b/docs/src/content/hooks/useCartItems.mdx
@@ -1,3 +1,7 @@
+---
+order: 2
+---
+
 import {ExampleUseCartItems, ExampleWithCode} from '../../components';
 
 ### useCartItems()

--- a/docs/src/content/hooks/useCheckoutUrl.mdx
+++ b/docs/src/content/hooks/useCheckoutUrl.mdx
@@ -1,3 +1,7 @@
+---
+order: 4
+---
+
 import {ExampleUseCheckoutUrl, ExampleWithCode} from '../../components';
 
 ### useCheckoutUrl()

--- a/docs/src/content/hooks/useRemoveItemFromCart.mdx
+++ b/docs/src/content/hooks/useRemoveItemFromCart.mdx
@@ -1,3 +1,7 @@
+---
+order: 8
+---
+
 import {ExampleUseRemoveItemFromCart, ExampleWithCode} from '../../components';
 
 ### useRemoveItemFromCart()

--- a/docs/src/content/hooks/useRemoveItemsFromCart.mdx
+++ b/docs/src/content/hooks/useRemoveItemsFromCart.mdx
@@ -1,3 +1,7 @@
+---
+order: 7
+---
+
 import {ExampleUseRemoveItemsFromCart, ExampleWithCode} from '../../components';
 
 ### useRemoveItemsFromCart()

--- a/docs/src/content/hooks/useUpdateItemQuantity.mdx
+++ b/docs/src/content/hooks/useUpdateItemQuantity.mdx
@@ -1,0 +1,70 @@
+---
+order: 9
+---
+
+import {ExampleUseUpdateItemQuantity, ExampleWithCode} from '../../components';
+
+### useUpdateItemQuantity()
+
+The `useUpdateItemQuantity()` hook returns a function that updates the quantity of a lineitem currently in the cart. The returned function accepts two arguments: `variantId` and `quantity`. It returns a `void` Promise that throws if it encounters an error. If `0` is passed in as the quantity, it removes the item from the cart.
+
+<ExampleWithCode element={<ExampleUseUpdateItemQuantity />}>
+
+```javascript
+import React, {useState} from 'react';
+import {Flex, Button, Input} from 'theme-ui';
+import {
+  useUpdateItemQuantity,
+  useCartItems,
+} from 'gatsby-theme-shopify-manager';
+
+export function ExampleUseUpdateItemQuantity() {
+  const [quantity, setQuantity] = useState(1);
+  const [item] = useCartItems();
+  const updateItemQuantity = useUpdateItemQuantity();
+
+  async function updateQuantity() {
+    if (item == null) {
+      return;
+    }
+
+    const variantId = item.variant.id;
+
+    try {
+      await updateItemQuantity(variantId, quantity);
+      alert('Successfully updated the item quantity!');
+    } catch {
+      alert("There was a problem updating that item's quantity.");
+    }
+  }
+
+  const itemMarkup =
+    item == null ? (
+      <p>Your cart is empty.</p>
+    ) : (
+      <p>
+        {item.title} - {item.variant.title} ({item.quantity})
+      </p>
+    );
+
+  const formMarkup = (
+    <Flex sx={{alignItems: 'flex-start'}} as="form" onSubmit={updateQuantity}>
+      <Input
+        sx={{width: '50px', mr: 3}}
+        type="number"
+        defaultValue={quantity}
+        onChange={(event) => setQuantity(Number(event.target.value))}
+      />
+      <Button sx={{mb: 3}}>Update quantity</Button>
+    </Flex>
+  );
+
+  return (
+    <>
+      {itemMarkup}
+      {formMarkup}
+    </>
+  );
+}
+```
+</ExampleWithCode>


### PR DESCRIPTION
This PR:
- Adds docs for `useUpdateItemQuantity`
- Adds a frontmatter bit for `order` so the order can be set for the hooks documentation
- Adds a `Link` component to standardize styles