### PR TITLE
[Feature] Theme option: shouldIncludeSourcePlugin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "gatsby-image": "^2.2.41",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-filesystem": "^2.2.2",
-    "gatsby-theme-shopify-manager": "0.1.0-alpha",
+    "gatsby-theme-shopify-manager": "0.1.2",
     "gatsby-transformer-sharp": "^2.3.16",
     "prism-themes": "^1.3.0",
     "react": "^16.8.0",

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -40,10 +40,11 @@ When you use this theme, it automatically includes `gatsby-source-shopify` and s
 
 ### Configuration options
 
-| key         | required | description                                                                                                                    |
-| ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| shopName    | yes      | This is the first part of the default Shopify domain. If your domain is my-store.myshopify.com, the shopName would be my-shop. |
-| accessToken | yes      | This is the Storefront API token that you get when you make a new Shopify app.                                                 |
+| key           | default | description                                                                                                                    |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `shopName`    | `null`  | This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-shop`. |
+| `accessToken` | `null`  | This is the Storefront API token that you get when you make a new Shopify app.                                                 |
+| `shouldIncludeSourcePlugin` | `true`  | By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` plugin. If you need to do advanced configuration of that plugin, pass `false` to this option. |
 
 ## Context Provider
 

--- a/gatsby-theme-shopify-manager/defaults.js
+++ b/gatsby-theme-shopify-manager/defaults.js
@@ -1,0 +1,16 @@
+// got this pattern/idea from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-theme-blog-core/gatsby-config.js
+module.exports = (themeOptions) => {
+  const shouldIncludeSourcePlugin =
+    themeOptions.shouldIncludeSourcePlugin != null
+      ? themeOptions.shouldIncludeSourcePlugin
+      : true;
+
+  const shopName = themeOptions.shopName || null;
+  const accessToken = themeOptions.accessToken || null;
+
+  return {
+    shouldIncludeSourcePlugin,
+    shopName,
+    accessToken,
+  };
+};

--- a/gatsby-theme-shopify-manager/gatsby-config.js
+++ b/gatsby-theme-shopify-manager/gatsby-config.js
@@ -1,18 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const withDefaults = require(`./defaults`);
+
 module.exports = (themeOptions) => {
-  if (themeOptions.shopName == null || themeOptions.accessToken == null) {
+  const options = withDefaults(themeOptions);
+  const {shouldIncludeSourcePlugin, shopName, accessToken} = options;
+
+  if (shouldIncludeSourcePlugin && (shopName == null || accessToken == null)) {
     throw new Error('You forgot to provide a shopName and/or accessToken');
   }
 
-  return {
-    plugins: [
-      'gatsby-plugin-typescript',
-      {
+  const shopifySourcePlugin = shouldIncludeSourcePlugin
+    ? {
         resolve: `gatsby-source-shopify`,
         options: {
-          shopName: themeOptions.shopName,
-          accessToken: themeOptions.accessToken,
+          shopName,
+          accessToken,
         },
-      },
-    ],
+      }
+    : null;
+
+  const plugins = ['gatsby-plugin-typescript', shopifySourcePlugin].filter(
+    Boolean,
+  );
+
+  return {
+    plugins,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6901,15 +6901,6 @@ gatsby-telemetry@^1.2.1:
     stack-utils "1.0.2"
     uuid "3.4.0"
 
-gatsby-theme-shopify-manager@0.1.0-alpha:
-  version "0.1.0-alpha"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-shopify-manager/-/gatsby-theme-shopify-manager-0.1.0-alpha.tgz#348c9cfee35cd115df3fb31210301a120001bebf"
-  integrity sha512-94OTCSLmRcrAK346BazNqvyR97jRPE3h7dQfq1zuenZSsi4t9FQIS4C6HuKDWLiOxgKUwJwx/2GvxeYXR/v9/Q==
-  dependencies:
-    dotenv "^8.2.0"
-    gatsby-source-shopify "^3.0.43"
-    shopify-buy "^2.9.0"
-
 gatsby-transformer-remark@^2.6.6:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-2.7.1.tgz#986871c3ca9a1b7d1c609e8f378a68d808827770"


### PR DESCRIPTION
This PR adds a theme option for `shouldIncludeSourcePlugin` to disable using the Shopify plugin as part of the `gatsby-config`. This PR includes documentation for the change as well.