### PR TITLE
[Feature] Theme options: shouldWrapRootElementWithProvider

### DIFF
--- a/docs/src/components/Hero.js
+++ b/docs/src/components/Hero.js
@@ -26,7 +26,10 @@ export function Hero() {
         <Text sx={{color: 'heading'}}>{description}</Text>
       </Box>
       <Box>
-        <img src={HipsterWithMac} />
+        <img
+          alt="A cheery-looking hipster holding a laptop wearing a yellow shirt, a black hat, and glasses"
+          src={HipsterWithMac}
+        />
       </Box>
     </Flex>
   );

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -40,15 +40,18 @@ When you use this theme, it automatically includes `gatsby-source-shopify` and s
 
 ### Configuration options
 
-| key           | default | description                                                                                                                    |
-| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `shopName`    | `null`  | This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-shop`. |
-| `accessToken` | `null`  | This is the Storefront API token that you get when you make a new Shopify app.                                                 |
-| `shouldIncludeSourcePlugin` | `true`  | By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` plugin. If you need to do advanced configuration of that plugin, pass `false` to this option. |
+| key                                 | default | description                                                                                                                    |
+| ----------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `shopName`                          | `null`  | This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-shop`. |
+| `accessToken`                       | `null`  | This is the Storefront API token that you get when you make a new Shopify app.                                                 |
+| `shouldIncludeSourcePlugin`         | `true`  | By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` plugin. If you need to do advanced configuration of that plugin, pass `false` to this option, and the `gatsby-source-shopify` plugin will not be included. |
+| `shouldWrapRootElementWithProvider` | `true`  | By default, `gatsby-theme-shopify-manager` wraps the application in a `<ContextProvider>`, and passes the `shopName` and `accessToken` provided to the theme options through to the provider. Pass `false` to this option to prevent this behavior. |
 
 ## Context Provider
 
 The Shopify buy client and current cart state are managed using React context. By default, the application is wrapped by the Provider and the `shopName` and `accessToken` are pulled from the config options and passed to it. However, in some cases, it might be preferable to manage the provider.
+
+> By default, `gatsby-theme-shopify-manager` wraps the application in a provider. If you want to manage this yourself, pass `shouldWrapRootElementWithProvider: false` to the theme options. If you don't, you'll have multiple providers that may result in unintended side-effects.
 
 To use the provider, import it and pass `shopName` and `accessToken` to it as props.
 

--- a/gatsby-theme-shopify-manager/defaults.js
+++ b/gatsby-theme-shopify-manager/defaults.js
@@ -5,11 +5,17 @@ module.exports = (themeOptions) => {
       ? themeOptions.shouldIncludeSourcePlugin
       : true;
 
+  const shouldWrapRootElementWithProvider =
+    themeOptions.shouldWrapRootElementWithProvider != null
+      ? themeOptions.shouldWrapRootElementWithProvider
+      : true;
+
   const shopName = themeOptions.shopName || null;
   const accessToken = themeOptions.accessToken || null;
 
   return {
     shouldIncludeSourcePlugin,
+    shouldWrapRootElementWithProvider,
     shopName,
     accessToken,
   };

--- a/gatsby-theme-shopify-manager/gatsby-browser.js
+++ b/gatsby-theme-shopify-manager/gatsby-browser.js
@@ -1,7 +1,24 @@
 import React from 'react';
 import {ContextProvider} from './src';
-export const wrapRootElement = ({element}, pluginOptions) => {
-  const {shopName, accessToken} = pluginOptions;
+import withDefaults from './defaults';
+
+export const wrapRootElement = ({element}, themeOptions) => {
+  const {
+    shouldWrapRootElementWithProvider,
+    shopName,
+    accessToken,
+  } = withDefaults(themeOptions);
+
+  if (shouldWrapRootElementWithProvider === false) {
+    return element;
+  }
+
+  const missingApiInformation = shopName == null || accessToken == null;
+  if (missingApiInformation) {
+    throw new Error(
+      'gatsby-theme-shopify-manager: You forgot to pass in a shopName or accessToken to the theme options',
+    );
+  }
 
   return (
     <ContextProvider shopName={shopName} accessToken={accessToken}>

--- a/gatsby-theme-shopify-manager/gatsby-config.js
+++ b/gatsby-theme-shopify-manager/gatsby-config.js
@@ -3,10 +3,22 @@ const withDefaults = require(`./defaults`);
 
 module.exports = (themeOptions) => {
   const options = withDefaults(themeOptions);
-  const {shouldIncludeSourcePlugin, shopName, accessToken} = options;
+  const {
+    shouldIncludeSourcePlugin,
+    shouldWrapRootElementWithProvider,
+    shopName,
+    accessToken,
+  } = options;
 
-  if (shouldIncludeSourcePlugin && (shopName == null || accessToken == null)) {
-    throw new Error('You forgot to provide a shopName and/or accessToken');
+  const needsApiInformation =
+    shouldIncludeSourcePlugin === true ||
+    shouldWrapRootElementWithProvider === true;
+  const missingApiInformation = shopName == null || accessToken == null;
+
+  if (needsApiInformation && missingApiInformation) {
+    throw new Error(
+      'gatsby-theme-shopify-manager: You forgot to pass in a shopName or accessToken to the theme options',
+    );
   }
 
   const shopifySourcePlugin = shouldIncludeSourcePlugin


### PR DESCRIPTION
This PR adds a theme option to enable/disable wrapping the root element in a `ContextProvider`.