### PR TITLE
Support custom domain names in config options

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -60,7 +60,7 @@ In case you're looking for a quick copy and paste 👇:
 {
   resolve: `gatsby-theme-shopify-manager`,
   options: {
-    shopName: 'your-shop-name',
+    shopName: 'your-shop-name', // or custom domain
     accessToken: 'your-api-access-token',
     shouldIncludeSourcePlugin: false, // default
     shouldWrapRootElementWithProvider: false, // default
@@ -70,12 +70,12 @@ In case you're looking for a quick copy and paste 👇:
 
 #### shopName
 
-This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-shop`. This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
+This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-store`. If you're using a custom domain with Shopify, you should enter your custom domain instead (e.g. `mystore.com`). This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
 ```javascript
 {
   resolve: `gatsby-theme-shopify-manager`,
   options: {
-    shopName: 'my-store',
+    shopName: 'my-store', // or mystore.com
   },
 },
 ```

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -70,7 +70,9 @@ In case you're looking for a quick copy and paste 👇:
 
 #### shopName
 
-This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-store`. If you're using a custom domain with Shopify, you should enter your custom domain instead (e.g. `mystore.com`). This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
+This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-store`. This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
+
+If you're using a custom domain with Shopify, you should enter your custom domain instead (e.g. `mystore.com`). Make sure to only include the name and domain, and omit the protocol (`http`) and any trailing slashes.
 ```javascript
 {
   resolve: `gatsby-theme-shopify-manager`,

--- a/gatsby-theme-shopify-manager/src/ContextProvider.tsx
+++ b/gatsby-theme-shopify-manager/src/ContextProvider.tsx
@@ -18,7 +18,7 @@ export function ContextProvider({shopName, accessToken, children}: Props) {
 
   const initialCart = LocalStorage.getInitialCart();
   const [cart, setCart] = useState<ShopifyBuy.Cart | null>(initialCart);
-  
+
   // shopName is a custom domain if it includes a period. free shopNames (URLs) cannot include periods. TODO: Is it better to add a theme config option for "customDomain" instead?
   const isCustomDomain = shopName.includes('.');
 

--- a/gatsby-theme-shopify-manager/src/ContextProvider.tsx
+++ b/gatsby-theme-shopify-manager/src/ContextProvider.tsx
@@ -19,7 +19,6 @@ export function ContextProvider({shopName, accessToken, children}: Props) {
   const initialCart = LocalStorage.getInitialCart();
   const [cart, setCart] = useState<ShopifyBuy.Cart | null>(initialCart);
 
-  // shopName is a custom domain if it includes a period. free shopNames (URLs) cannot include periods. TODO: Is it better to add a theme config option for "customDomain" instead?
   const isCustomDomain = shopName.includes('.');
 
   const client = ShopifyBuy.buildClient({

--- a/gatsby-theme-shopify-manager/src/ContextProvider.tsx
+++ b/gatsby-theme-shopify-manager/src/ContextProvider.tsx
@@ -18,9 +18,13 @@ export function ContextProvider({shopName, accessToken, children}: Props) {
 
   const initialCart = LocalStorage.getInitialCart();
   const [cart, setCart] = useState<ShopifyBuy.Cart | null>(initialCart);
+  
+  // shopName is a custom domain if it includes a period. free shopNames (URLs) cannot include periods. TODO: Is it better to add a theme config option for "customDomain" instead?
+  const isCustomDomain = shopName.includes('.');
+
   const client = ShopifyBuy.buildClient({
     storefrontAccessToken: accessToken,
-    domain: `${shopName}.myshopify.com`,
+    domain: isCustomDomain ? shopName : `${shopName}.myshopify.com`,
   });
 
   useEffect(() => {

--- a/gatsby-theme-shopify-manager/src/__tests__/ContextProvider.test.tsx
+++ b/gatsby-theme-shopify-manager/src/__tests__/ContextProvider.test.tsx
@@ -75,7 +75,47 @@ describe('ContextProvider', () => {
     await wait(() =>
       expect(shopifyBuySpy).toHaveBeenCalledWith({
         storefrontAccessToken: Mocks.ACCESS_TOKEN,
-        domain: Mocks.DOMAIN,
+        domain: Mocks.MYSHOPIFY_DOMAIN,
+      }),
+    );
+  });
+
+  it('appends ".myshopify.com" to shopName when customDomain evaluates false', async () => {
+    const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
+
+    render(
+      <ContextProvider
+        shopName={Mocks.SHOP_NAME}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
+        <MockComponent />
+      </ContextProvider>,
+    );
+
+    await wait(() =>
+      expect(shopifyBuySpy).toHaveBeenCalledWith({
+        storefrontAccessToken: Mocks.ACCESS_TOKEN,
+        domain: Mocks.MYSHOPIFY_DOMAIN,
+      }),
+    );
+  });
+
+  it('does not append ".myshopify.com" to shopName when customDomain evaluates true', async () => {
+    const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
+
+    render(
+      <ContextProvider
+        shopName={Mocks.SHOP_NAME_WITH_CUSTOM_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
+        <MockComponent />
+      </ContextProvider>,
+    );
+
+    await wait(() =>
+      expect(shopifyBuySpy).toHaveBeenCalledWith({
+        storefrontAccessToken: Mocks.ACCESS_TOKEN,
+        domain: Mocks.CUSTOM_DOMAIN,
       }),
     );
   });
@@ -84,7 +124,10 @@ describe('ContextProvider', () => {
     const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
 
     render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -153,7 +196,10 @@ describe('ContextProvider', () => {
     }
 
     const {getByText} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -179,7 +225,10 @@ describe('ContextProvider', () => {
     }
 
     const {asFragment} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -204,7 +253,10 @@ describe('ContextProvider', () => {
     }
 
     const {asFragment} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -231,7 +283,10 @@ describe('ContextProvider', () => {
     }
 
     const {asFragment} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -262,7 +317,10 @@ describe('ContextProvider', () => {
     }
 
     const {asFragment} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -294,7 +352,10 @@ describe('ContextProvider', () => {
     }
 
     const {asFragment} = render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );
@@ -326,7 +387,10 @@ describe('ContextProvider', () => {
     }
 
     render(
-      <ContextProvider shopName={Mocks.DOMAIN} accessToken={Mocks.ACCESS_TOKEN}>
+      <ContextProvider
+        shopName={Mocks.MYSHOPIFY_DOMAIN}
+        accessToken={Mocks.ACCESS_TOKEN}
+      >
         <MockComponent />
       </ContextProvider>,
     );

--- a/gatsby-theme-shopify-manager/src/__tests__/ContextProvider.test.tsx
+++ b/gatsby-theme-shopify-manager/src/__tests__/ContextProvider.test.tsx
@@ -80,7 +80,7 @@ describe('ContextProvider', () => {
     );
   });
 
-  it('appends ".myshopify.com" to shopName when customDomain evaluates false', async () => {
+  it('appends ".myshopify.com" to shopName when shopName is not a custom domain', async () => {
     const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
 
     render(
@@ -100,7 +100,7 @@ describe('ContextProvider', () => {
     );
   });
 
-  it('does not append ".myshopify.com" to shopName when customDomain evaluates true', async () => {
+  it('does not append ".myshopify.com" to shopName when shopName is a custom domain', async () => {
     const shopifyBuySpy = jest.spyOn(ShopifyBuy, 'buildClient');
 
     render(
@@ -115,7 +115,7 @@ describe('ContextProvider', () => {
     await wait(() =>
       expect(shopifyBuySpy).toHaveBeenCalledWith({
         storefrontAccessToken: Mocks.ACCESS_TOKEN,
-        domain: Mocks.CUSTOM_DOMAIN,
+        domain: Mocks.SHOP_NAME_WITH_CUSTOM_DOMAIN,
       }),
     );
   });

--- a/gatsby-theme-shopify-manager/src/mocks/constants.ts
+++ b/gatsby-theme-shopify-manager/src/mocks/constants.ts
@@ -1,3 +1,6 @@
 export const ACCESS_TOKEN = 'access123';
 export const SHOP_NAME = 'some-shop';
-export const DOMAIN = `${SHOP_NAME}.myshopify.com`;
+export const SHOP_NAME_WITH_CUSTOM_DOMAIN = 'some-shop.com';
+
+export const MYSHOPIFY_DOMAIN = `${SHOP_NAME}.myshopify.com`;
+export const CUSTOM_DOMAIN = 'some-shop.com';

--- a/gatsby-theme-shopify-manager/src/mocks/constants.ts
+++ b/gatsby-theme-shopify-manager/src/mocks/constants.ts
@@ -1,6 +1,4 @@
 export const ACCESS_TOKEN = 'access123';
 export const SHOP_NAME = 'some-shop';
 export const SHOP_NAME_WITH_CUSTOM_DOMAIN = 'some-shop.com';
-
 export const MYSHOPIFY_DOMAIN = `${SHOP_NAME}.myshopify.com`;
-export const CUSTOM_DOMAIN = 'some-shop.com';

--- a/gatsby-theme-shopify-manager/src/mocks/contextWrappers/wrapWithContext.tsx
+++ b/gatsby-theme-shopify-manager/src/mocks/contextWrappers/wrapWithContext.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {ContextProvider} from '../../ContextProvider';
-import {DOMAIN, ACCESS_TOKEN} from '../constants';
+import {MYSHOPIFY_DOMAIN, ACCESS_TOKEN} from '../constants';
 import {CART} from '../cart';
 import {ContextOptions} from './types';
 import {LocalStorage, LocalStorageKeys} from '../../utils';
 
 export function wrapWithContext(givenOptions?: Partial<ContextOptions>) {
   const defaults = {
-    shopName: DOMAIN,
+    shopName: MYSHOPIFY_DOMAIN,
     accessToken: ACCESS_TOKEN,
     shouldSetInitialCart: true,
   };

--- a/gatsby-theme-shopify-manager/src/mocks/index.ts
+++ b/gatsby-theme-shopify-manager/src/mocks/index.ts
@@ -2,7 +2,13 @@ import {CART, VARIANT_ID_IN_CART, CHECKOUT_URL} from './cart';
 import {EMPTY_CART} from './emptyCart';
 import {PURCHASED_CART} from './purchasedCart';
 import {CLIENT} from './client';
-import {ACCESS_TOKEN, SHOP_NAME, DOMAIN} from './constants';
+import {
+  ACCESS_TOKEN,
+  SHOP_NAME,
+  SHOP_NAME_WITH_CUSTOM_DOMAIN,
+  MYSHOPIFY_DOMAIN,
+  CUSTOM_DOMAIN,
+} from './constants';
 import {
   wrapWithContext,
   renderWithContext,
@@ -18,7 +24,9 @@ const Mocks = {
   CLIENT,
   ACCESS_TOKEN,
   SHOP_NAME,
-  DOMAIN,
+  SHOP_NAME_WITH_CUSTOM_DOMAIN,
+  MYSHOPIFY_DOMAIN,
+  CUSTOM_DOMAIN,
   VARIANT_ID_IN_CART,
   CHECKOUT_URL,
 };

--- a/gatsby-theme-shopify-manager/src/mocks/index.ts
+++ b/gatsby-theme-shopify-manager/src/mocks/index.ts
@@ -7,7 +7,6 @@ import {
   SHOP_NAME,
   SHOP_NAME_WITH_CUSTOM_DOMAIN,
   MYSHOPIFY_DOMAIN,
-  CUSTOM_DOMAIN,
 } from './constants';
 import {
   wrapWithContext,
@@ -26,7 +25,6 @@ const Mocks = {
   SHOP_NAME,
   SHOP_NAME_WITH_CUSTOM_DOMAIN,
   MYSHOPIFY_DOMAIN,
-  CUSTOM_DOMAIN,
   VARIANT_ID_IN_CART,
   CHECKOUT_URL,
 };

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "prettier": "^1.19.1",
     "react-test-renderer": "^16.13.0"
   },
-  "version": "0.0.0"
+  "version": "0.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "prettier": "^1.19.1",
     "react-test-renderer": "^16.13.0"
   },
-  "version": "0.0.1"
+  "version": "0.1.7"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "prettier": "^1.19.1",
     "react-test-renderer": "^16.13.0"
   },
-  "version": "0.1.7"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
Check if the shopName includes a period. If it does, it must be a custom domain. If it is a custom domain, we do not append ".myshopify.com" to the end of the shop name.