### PR TITLE
chore: add keywords to package.json

### DIFF
--- a/gatsby-theme-shopify-manager/package.json
+++ b/gatsby-theme-shopify-manager/package.json
@@ -28,6 +28,8 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
+    "gatsby-theme",
     "shopify"
   ],
   "author": "Trevor Harmon <thetrevorharmon@gmail.com> (http://thetrevorhamon.com)",


### PR DESCRIPTION
Adding `gatsby-plugin` will make this show up in the [plugin library](https://www.gatsbyjs.org/plugins/). Maybe one day the `gatsby-theme` keyword will be used for a theme marketplace, though some themes are tagged with it.