### PR TITLE
Decouple gatsby-source-shopify

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
     "gatsby-plugin-react-helmet": "^3.3.1",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-source-filesystem": "^2.2.2",
+    "gatsby-source-shopify": "^3.2.30",
     "gatsby-theme-shopify-manager": "0.1.7",
     "gatsby-transformer-sharp": "^2.3.16",
     "prism-themes": "^1.3.0",

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -28,7 +28,7 @@ This is a data theme, not a UI theme. It makes setting up a Shopify cart and buy
 To start using the theme, install it with your package manager of choice:
 
 ```bash
-yarn add gatsby-theme-shopify-manager
+yarn add gatsby-theme-shopify-manager gatsby-source-shopify
 ```
 
 To start using it, open your `gatsby-config` file and include your Shop name and access token from the Storefront API.
@@ -43,7 +43,7 @@ To start using it, open your `gatsby-config` file and include your Shop name and
 },
 ```
 
-When you use this theme, it automatically includes `gatsby-source-shopify` and sets it up for you. These options are passed to that package, as well as used internally to create a connection to Shopify using [shopify-buy](https://shopify.github.io/js-buy-sdk/).
+The options you pass to this theme are used to configure both `gatsby-source-shopify` and the [shopify-buy](https://shopify.github.io/js-buy-sdk/) client.
 
 ### Configuration options
 
@@ -96,7 +96,7 @@ This is the Storefront API token that you get when you make a new Shopify app. T
 
 #### shouldConfigureSourcePlugin
 
-By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` plugin. If you need to do advanced configuration of that plugin, pass `false` to this option, and the `gatsby-source-shopify` plugin will not be included.
+By default, `gatsby-theme-shopify-manager` passes a configuration object to the `gatsby-source-shopify` plugin in `gatsby-config`. If you need to do advanced configuration of that plugin, pass `false` to this option. From there, you can set up and configure your source plugin as you please.
 ```javascript
 {
   resolve: `gatsby-theme-shopify-manager`,

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -51,7 +51,7 @@ There are four options to configure this theme, with only the first two being re
   
 1. [shopName](/#shopname)
 1. [accessToken](/#accesstoken)
-1. [shouldIncludeSourcePlugin](/#shouldincludesourceplugin)
+1. [shouldConfigureSourcePlugin](/#shouldConfigureSourcePlugin)
 1. [shouldWrapRootElementWithProvider](/#shouldwraprootelementwithprovider)
 
 In case you're looking for a quick copy and paste 👇:
@@ -62,7 +62,7 @@ In case you're looking for a quick copy and paste 👇:
   options: {
     shopName: 'your-shop-name', // or custom domain
     accessToken: 'your-api-access-token',
-    shouldIncludeSourcePlugin: false, // default
+    shouldConfigureSourcePlugin: false, // default
     shouldWrapRootElementWithProvider: false, // default
   },
 },
@@ -70,7 +70,7 @@ In case you're looking for a quick copy and paste 👇:
 
 #### shopName
 
-This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-store`. This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
+This is the first part of the default Shopify domain. If your domain is `my-store.myshopify.com`, the shopName would be `my-store`. This value is required unless you pass `false` to both `shouldConfigureSourcePlugin` and `shouldWrapRootElementWithProvider`.
 
 If you're using a custom domain with Shopify, you should enter your custom domain instead (e.g. `mystore.com`). Make sure to only include the name and domain, and omit the protocol (`http`) and any trailing slashes.
 ```javascript
@@ -84,7 +84,7 @@ If you're using a custom domain with Shopify, you should enter your custom domai
 
 #### accessToken
 
-This is the Storefront API token that you get when you make a new Shopify app. This value is required unless you pass `false` to both `shouldIncludeSourcePlugin` and `shouldWrapRootElementWithProvider`.
+This is the Storefront API token that you get when you make a new Shopify app. This value is required unless you pass `false` to both `shouldConfigureSourcePlugin` and `shouldWrapRootElementWithProvider`.
 ```javascript
 {
   resolve: `gatsby-theme-shopify-manager`,
@@ -94,7 +94,7 @@ This is the Storefront API token that you get when you make a new Shopify app. T
 },
 ```
 
-#### shouldIncludeSourcePlugin
+#### shouldConfigureSourcePlugin
 
 By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` plugin. If you need to do advanced configuration of that plugin, pass `false` to this option, and the `gatsby-source-shopify` plugin will not be included.
 ```javascript
@@ -102,7 +102,7 @@ By default, `gatsby-theme-shopify-manager` includes the `gatsby-source-shopify` 
   resolve: `gatsby-theme-shopify-manager`,
   options: {
     // default value is true
-    shouldIncludeSourcePlugin: false
+    shouldConfigureSourcePlugin: false
   },
 },
 ```

--- a/gatsby-theme-shopify-manager/defaults.js
+++ b/gatsby-theme-shopify-manager/defaults.js
@@ -1,8 +1,8 @@
 // got this pattern/idea from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-theme-blog-core/gatsby-config.js
 module.exports = (themeOptions) => {
-  const shouldIncludeSourcePlugin =
-    themeOptions.shouldIncludeSourcePlugin != null
-      ? themeOptions.shouldIncludeSourcePlugin
+  const shouldConfigureSourcePlugin =
+    themeOptions.shouldConfigureSourcePlugin != null
+      ? themeOptions.shouldConfigureSourcePlugin
       : true;
 
   const shouldWrapRootElementWithProvider =
@@ -14,7 +14,7 @@ module.exports = (themeOptions) => {
   const accessToken = themeOptions.accessToken || null;
 
   return {
-    shouldIncludeSourcePlugin,
+    shouldConfigureSourcePlugin,
     shouldWrapRootElementWithProvider,
     shopName,
     accessToken,

--- a/gatsby-theme-shopify-manager/gatsby-config.js
+++ b/gatsby-theme-shopify-manager/gatsby-config.js
@@ -4,14 +4,14 @@ const withDefaults = require(`./defaults`);
 module.exports = (themeOptions) => {
   const options = withDefaults(themeOptions);
   const {
-    shouldIncludeSourcePlugin,
+    shouldConfigureSourcePlugin,
     shouldWrapRootElementWithProvider,
     shopName,
     accessToken,
   } = options;
 
   const needsApiInformation =
-    shouldIncludeSourcePlugin === true ||
+    shouldConfigureSourcePlugin === true ||
     shouldWrapRootElementWithProvider === true;
   const missingApiInformation = shopName == null || accessToken == null;
 
@@ -21,7 +21,7 @@ module.exports = (themeOptions) => {
     );
   }
 
-  const shopifySourcePlugin = shouldIncludeSourcePlugin
+  const shopifySourcePlugin = shouldConfigureSourcePlugin
     ? {
         resolve: `gatsby-source-shopify`,
         options: {

--- a/gatsby-theme-shopify-manager/package.json
+++ b/gatsby-theme-shopify-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-shopify-manager",
   "description": "The easiest way to build a Shopify shop on Gatsby.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -19,9 +19,6 @@
     "gatsby-plugin-typescript": "^2.1.27",
     "shopify-buy": "^2.9.0",
     "typescript": "^3.7.5"
-  },
-  "optionalDependencies": {
-    "gatsby-source-shopify": "^3.0.43"
   },
   "devDependencies": {
     "gatsby": "^2.19.18",

--- a/gatsby-theme-shopify-manager/package.json
+++ b/gatsby-theme-shopify-manager/package.json
@@ -17,9 +17,11 @@
     "@types/react-dom": "^16.9.5",
     "@types/shopify-buy": "^1.4.3",
     "gatsby-plugin-typescript": "^2.1.27",
-    "gatsby-source-shopify": "^3.0.43",
     "shopify-buy": "^2.9.0",
     "typescript": "^3.7.5"
+  },
+  "optionalDependencies": {
+    "gatsby-source-shopify": "^3.0.43"
   },
   "devDependencies": {
     "gatsby": "^2.19.18",

--- a/gatsby-theme-shopify-manager/package.json
+++ b/gatsby-theme-shopify-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-shopify-manager",
   "description": "The easiest way to build a Shopify shop on Gatsby.",
-  "version": "0.1.8",
+  "version": "0.1.7",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7646,7 +7646,7 @@ gatsby-source-filesystem@^2.2.2, gatsby-source-filesystem@^2.3.28:
     valid-url "^1.0.9"
     xstate "^4.11.0"
 
-gatsby-source-shopify@^3.0.43:
+gatsby-source-shopify@^3.2.30:
   version "3.2.30"
   resolved "https://registry.yarnpkg.com/gatsby-source-shopify/-/gatsby-source-shopify-3.2.30.tgz#8311d555fac9c3826ea38315658d21bc436eb3b9"
   integrity sha512-BImER0DzZva8wfOTds158IStXywgjoCaTBfTO8l5RlZJBvrqc7pohooACh5OsbuIOVNdPw2R7hJnlYzst6Uc2w==


### PR DESCRIPTION
This PR decouples `gatsby-source-shopify` in order to make custom configuration more straightforward.

See https://github.com/thetrevorharmon/gatsby-theme-shopify-manager/pull/57 for full details.